### PR TITLE
remove unused code from global_selection.cs

### DIFF
--- a/global_selection.cs
+++ b/global_selection.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class global_selection : MonoBehaviour
 {
-    id_dictionary id_table;
+    
     selected_dictionary selected_table;
     RaycastHit hit;
 
@@ -29,7 +29,7 @@ public class global_selection : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        id_table = GetComponent<id_dictionary>();
+        
         selected_table = GetComponent<selected_dictionary>();
         dragSelect = false;
     }


### PR DESCRIPTION
remove id_dictionary and id_table from global_selection.cs. They aren't used anywhere, and Unity pops an error due to needing the id_dictionary file.